### PR TITLE
adding render errors function

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,14 @@
 </head>
 
 <body>
+  <!-- Error Modal -->
+  <div id="error-modal" class="modal red darken-3 bottom-sheet white-text text-darken-3">
+    <div class="modal-content">
+    </div>
+    <div class="modal-footer red lighten-1">
+      <a href="#!" class="modal-close waves-effect red darken-3 waves-blue btn">Close</a>
+    </div>
+  </div>
   <!-- <div class="row">
         <div class="col s1">1</div>
         <div class="col s1">2</div>
@@ -78,9 +86,9 @@
 
 
     <!-- Compiled and minified JavaScript for Materialize -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
     <script src="https://code.jquery.com/jquery-3.4.1.min.js"
       integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 
     <!-- Our backend scripts -->
     <script src="./api.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,21 +1,20 @@
-
-getEverything({ q: 'pole vault', source: 'CNN' }).then((response) => {
+// test area --- not part of final product
+getEverything({q: 'pole vault', source: 'CNN'}).then((response) => {
   const { articles } = response;
 
   // var articles = response.articles;
   const { url } = articles[0];
 
-
   // var url = articles[0].url;
   // console.log({ url, googleResponse: response })
-
   renderTitles(articles)
 
   return getAnalysis({ url });
 }).then((response) => {
-
-
-})
+  console.log(response);
+}).catch(error => {
+  renderError(error);
+});
 
 
 function renderTitles(articles) {
@@ -48,3 +47,23 @@ function renderTitles(articles) {
 
 
 }
+
+const renderError = (error) => {
+  console.error(error);
+  console.log({error, error})
+  const modal = $('#error-modal');
+
+  const header = $('<h4>');
+  const paragraph = $('<p>');
+
+  header.text(`Error: ${error.code || ''}`);
+  paragraph.text(error.message || '');
+
+  $('#error-modal .modal-content').append(header, paragraph);
+
+  modal.modal('open');
+} 
+
+$(document).ready(function(){
+  $('.modal').modal();
+});


### PR DESCRIPTION
Close #20 

<img width="918" alt="image" src="https://user-images.githubusercontent.com/11727334/74401613-b4ce9900-4dd6-11ea-8c06-3e7f71f25c65.png">

We can throw my render errors function into any `.catch()` callback to have errors show up on the page. 